### PR TITLE
Looks like zci.answer should be printed whenever possible.

### DIFF
--- a/lib/modules/web/duckduckgo.rb
+++ b/lib/modules/web/duckduckgo.rb
@@ -16,11 +16,9 @@ linael :duckduckgo do
     # N (name), E (exclusive), or empty
     # see https://api.duckduckgo.com/api
 
-    if !zci.answer.empty?
-        answer(msg,"#{options.from_who}: #{zci.answer ?
-                                           zci.answer.ans.gsub(/.*}\\n/,"").gsub(/<(.*?)>/, "") :
-                                           zci.redirect}")
-    elsif !zci.type.empty?
+    if zci.answer
+        answer(msg,"#{options.from_who}: #{zci.answer.gsub(/.*\n/,"").gsub(/<(.*?)>/, "")}")
+    elsif zci.type
         begin
           send("answer_to_#{zci.type}",zci,msg,options)
         rescue NoMethodError


### PR DESCRIPTION
For `!ddg flip a coin` or `!ddg guid`, people had the excellent idea of **not** setting answer type to `E` (but `A`) so that we can't distinguish articles from some computed answers. _Real_ articles have no `zci.answer`, only `zci.abstract`/`zci.abstracttext`, so whenever possible, we should maybe just print `zci.answer`.
Also, ♥
